### PR TITLE
Support for buffer zone (ie. territorial waters = 12nm)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Given the latitude and longitude coordinates this package returns whether the po
 The package internally uses [@geo-maps/earth-seas](https://github.com/simonepri/geo-maps/blob/master/info/earth-seas.md) map with 10m resolution.
 The accuracy of the map has not been tested but the [demo](http://simonepri.github.io/is-sea/) allows you to actually test it manually by just clicking on the map to see what it returns.
 
-** Modified by Lee Prevost to use @geo-maps/
+** Modified by Lee Prevost to use @geo-maps/countries-maritime-10m for political maritime boundaries.
+See https://github.com/simonepri/geo-maps for demo.
 
 Do you believe that this is useful? If so, <a href="#start-of-content">support us with a ⭐️</a>!
 
-## Install
+## Install  (does not work for this fork)
 ```bash
 $ npm install --save is-sea
 ```
@@ -54,6 +55,7 @@ Returns wheather the given point is in the sea or not.
 
 ## Authors
 * **Simone Primarosa** - [simonepri](https://github.com/simonepri)
+* **Lee Prevost** - [leeprevost](https://github.com/leeprevost)
 
 See also the list of [contributors](https://github.com/simonepri/is-sea/contributors) who participated in this project.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # is-sea
 [![Travis CI](https://travis-ci.org/simonepri/is-sea.svg?branch=master)](https://travis-ci.org/simonepri/is-sea) [![Codecov](https://img.shields.io/codecov/c/github/simonepri/is-sea/master.svg)](https://codecov.io/gh/simonepri/is-sea) [![npm](https://img.shields.io/npm/dm/is-sea.svg)](https://www.npmjs.com/package/is-sea) [![npm version](https://img.shields.io/npm/v/is-sea.svg)](https://www.npmjs.com/package/is-sea) [![npm dependencies](https://david-dm.org/simonepri/is-sea.svg)](https://david-dm.org/simonepri/is-sea) [![npm dev dependencies](https://david-dm.org/simonepri/is-sea/dev-status.svg)](https://david-dm.org/simonepri/is-sea#info=devDependencies)
-> 🌊 Check whether a geographic coordinate is in the sea or not on the earth.
+> 🌊 Check whether a geographic coordinate on the Earth is in the sea or not.
 
 <p align="center">
   <a href="http://simonepri.github.io/is-sea/"><img src="https://raw.githubusercontent.com/simonepri/is-sea/master/demo/index.png" width="700"/></a>
@@ -13,6 +13,8 @@ Given the latitude and longitude coordinates this package returns whether the po
 
 The package internally uses [@geo-maps/earth-seas](https://github.com/simonepri/geo-maps/blob/master/info/earth-seas.md) map with 10m resolution.
 The accuracy of the map has not been tested but the [demo](http://simonepri.github.io/is-sea/) allows you to actually test it manually by just clicking on the map to see what it returns.
+
+** Modified by Lee Prevost to use @geo-maps/
 
 Do you believe that this is useful? If so, <a href="#start-of-content">support us with a ⭐️</a>!
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Returns wheather the given point is in the sea or not.
 
 ## Authors
 * **Simone Primarosa** - [simonepri](https://github.com/simonepri)
-* **Lee Prevost** - [leeprevost](https://github.com/leeprevost)
+
 
 See also the list of [contributors](https://github.com/simonepri/is-sea/contributors) who participated in this project.
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const GeoJsonLookup = require('geojson-geometries-lookup');
-const getMap = require('@geo-maps/earth-seas-10m');
-const buffer = require('@turf/buffer');
+const getMap = require('@geo-maps/countries-maritime-10m');  //changed to maritime sea boundaries.  May need to negate boolean response of hasContainers method.
 
 let landLookup = null;
 
@@ -11,16 +10,11 @@ let landLookup = null;
  * @public
  * @param {number} lat  The latitude of the point.
  * @param {number} lng  The longitude of the point.
- * @param {radius}, optional, distance to draw the buffer around/within earth-seas boundary.   12 nautical miles is territorial boundary.   https://en.wikipedia.org/wiki/Territorial_waters
- * @param {units}, valid units: default is 'nauticalmiles'.  accepted units are defind by turf module convert Length http://turfjs.org/docs/#convertLength 
  * @return {boolean} True if the point is in the sea, false otherwise.
  */
 function isSea(lat, lng, radius=0, units='nauticalmiles') {
   if (landLookup === null) {
     const map = getMap();
-    if buffer > 0 {
-      map = buffer(map, radius, {units: units})
-    }
     landLookup = new GeoJsonLookup(map);
   }
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const GeoJsonLookup = require('geojson-geometries-lookup');
 const getMap = require('@geo-maps/earth-seas-10m');
+const buffer = require('@turf/buffer');
 
 let landLookup = null;
 
@@ -10,11 +11,16 @@ let landLookup = null;
  * @public
  * @param {number} lat  The latitude of the point.
  * @param {number} lng  The longitude of the point.
+ * @param {radius}, optional, distance to draw the buffer around/within earth-seas boundary.   12 nautical miles is territorial boundary.   https://en.wikipedia.org/wiki/Territorial_waters
+ * @param {units}, valid units: default is kilometers.  typical is nauticalmiles http://turfjs.org/docs/#convertLength 
  * @return {boolean} True if the point is in the sea, false otherwise.
  */
-function isSea(lat, lng) {
+function isSea(lat, lng, radius=0, units='nauticalmiles') {
   if (landLookup === null) {
     const map = getMap();
+    if buffer > 0 {
+      map = buffer(map, radius, {units: units})
+    }
     landLookup = new GeoJsonLookup(map);
   }
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ let landLookup = null;
  * @param {number} lat  The latitude of the point.
  * @param {number} lng  The longitude of the point.
  * @param {radius}, optional, distance to draw the buffer around/within earth-seas boundary.   12 nautical miles is territorial boundary.   https://en.wikipedia.org/wiki/Territorial_waters
- * @param {units}, valid units: default is kilometers.  typical is nauticalmiles http://turfjs.org/docs/#convertLength 
+ * @param {units}, valid units: default is 'nauticalmiles'.  accepted units are defind by turf module convert Length http://turfjs.org/docs/#convertLength 
  * @return {boolean} True if the point is in the sea, false otherwise.
  */
 function isSea(lat, lng, radius=0, units='nauticalmiles') {

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function isSea(lat, lng, radius=0, units='nauticalmiles') {
     landLookup = new GeoJsonLookup(map);
   }
 
-  return landLookup.hasContainers({type: 'Point', coordinates: [lng, lat]});
+  return !landLookup.hasContainers({type: 'Point', coordinates: [lng, lat]});   //returned logical not since this looking for points contained by containers in sea.
 }
 
 module.exports = isSea;

--- a/index.js
+++ b/index.js
@@ -11,14 +11,15 @@ let landLookup = null;
  * @public
  * @param {number} lat  The latitude of the point.
  * @param {number} lng  The longitude of the point.
- * @param {radius}, optional, distance to draw the buffer around/within earth-seas boundary.   12 nautical miles is territorial boundary.   https://en.wikipedia.org/wiki/Territorial_waters
+ * @param {radius}, optional, distance to draw the buffer around/within earth-seas boundary (allows neg number).   12 nautical miles is territorial boundary.   
+ * https://en.wikipedia.org/wiki/Territorial_waters
  * @param {units}, valid units: default is 'nauticalmiles'.  accepted units are defind by turf module convert Length http://turfjs.org/docs/#convertLength 
  * @return {boolean} True if the point is in the sea, false otherwise.
  */
 function isSea(lat, lng, radius=0, units='nauticalmiles') {
   if (landLookup === null) {
     const map = getMap();
-    if buffer > 0 {
+    if buffer != 0 {
       map = buffer(map, radius, {units: units})
     }
     landLookup = new GeoJsonLookup(map);

--- a/index.js
+++ b/index.js
@@ -11,15 +11,14 @@ let landLookup = null;
  * @public
  * @param {number} lat  The latitude of the point.
  * @param {number} lng  The longitude of the point.
- * @param {radius}, optional, distance to draw the buffer around/within earth-seas boundary (allows neg number).   12 nautical miles is territorial boundary.   
- * https://en.wikipedia.org/wiki/Territorial_waters
+ * @param {radius}, optional, distance to draw the buffer around/within earth-seas boundary.   12 nautical miles is territorial boundary.   https://en.wikipedia.org/wiki/Territorial_waters
  * @param {units}, valid units: default is 'nauticalmiles'.  accepted units are defind by turf module convert Length http://turfjs.org/docs/#convertLength 
  * @return {boolean} True if the point is in the sea, false otherwise.
  */
 function isSea(lat, lng, radius=0, units='nauticalmiles') {
   if (landLookup === null) {
     const map = getMap();
-    if buffer != 0 {
+    if buffer > 0 {
       map = buffer(map, radius, {units: units})
     }
     landLookup = new GeoJsonLookup(map);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "@geo-maps/earth-seas-10m": "^0.6.0",
-    "geojson-geometries-lookup": "^0.2.0"
+    "geojson-geometries-lookup": "^0.2.0",
+    "@turf/buffer"; "^6.5.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Check whether a geographic coordinate is in the sea or not on the earth.",
   "main": "index.js",
   "dependencies": {
+    "@geo-maps/countries-maritime-10m": "^0.6.0",
     "@geo-maps/earth-seas-10m": "^0.6.0",
-    "geojson-geometries-lookup": "^0.2.0",
-    "@turf/buffer": "^6.5.0"
+    "@turf/buffer": "^6.5.0",
+    "geojson-geometries-lookup": "^0.2.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "dependencies": {
     "@geo-maps/countries-maritime-10m": "^0.6.0",
     "@geo-maps/earth-seas-10m": "^0.6.0",
-    "@turf/buffer": "^6.5.0",
     "geojson-geometries-lookup": "^0.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@geo-maps/earth-seas-10m": "^0.6.0",
     "geojson-geometries-lookup": "^0.2.0",
-    "@turf/buffer"; "^6.5.0"
+    "@turf/buffer": "^6.5.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -14,6 +14,9 @@ test('42.105019N, 12.316765W should return false for a point in the lake', t => 
   t.false(m(42.105019, 12.316765));
 });
 
-test('41.753859N, 12.223008W should return true for a point in the sea', t => {
-  t.true(m(41.753859, 12.223008));
+// refactored to use maritime boundaries of 12nm.   Point in the sea more than 12nm.  
+// https://github.com/simonepri/geo-maps/blob/master/info/countries-maritime.md
+
+test('31.9592N,80.4570W should return true for a point in the sea', t => {
+  t.true(m(31.9592, 80.4570));
 });

--- a/test.js
+++ b/test.js
@@ -17,6 +17,6 @@ test('42.105019N, 12.316765W should return false for a point in the lake', t => 
 // refactored to use maritime boundaries of 12nm.   Point in the sea more than 12nm.  
 // https://github.com/simonepri/geo-maps/blob/master/info/countries-maritime.md
 
-test('31.9592N,80.4570W should return true for a point in the sea', t => {
-  t.true(m(31.9592, 80.4570));
+test('31.9592N,-80.4570W should return true for a point in the sea', t => {
+  t.true(m(31.9592, -80.4570));
 });


### PR DESCRIPTION
@simonepri - this was my attempt to add buffer zone logic to your is-sea module.   I updated index.js and package.json but did not update readme, demos, or test.   Was not sure how to do that as I'm more comfortable with python.   I thought adding the @turf/buffer module would be lighter weight than trying to import another map which has buffers drawn and would be especially 'lite' for raspi or embedded use aboard a vessel.  If you can guide me on whatelse needs added, I'll surely do my best to contribute.