### PR TITLE
docs: add Zenodo DOI, CITATION.cff, and citing-papers section

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using the metadata below."
+type: software
+title: is-sea
+abstract: Check whether a geographic coordinate is in the sea or not on the earth.
+authors:
+  - family-names: Primarosa
+    given-names: Simone
+repository-code: "https://github.com/simonepri/is-sea"
+url: "https://github.com/simonepri/is-sea"
+license: MIT
+date-released: 2017-12-01
+doi: 10.5281/zenodo.20585085
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.20585085
+    description: Concept DOI (resolves to the latest version)
+  - type: doi
+    value: 10.5281/zenodo.20585086
+    description: Version 0.3.1
+keywords:
+  - geojson
+  - geography
+  - sea
+  - ocean
+  - coordinates

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # is-sea
-[![Travis CI](https://travis-ci.org/simonepri/is-sea.svg?branch=master)](https://travis-ci.org/simonepri/is-sea) [![Codecov](https://img.shields.io/codecov/c/github/simonepri/is-sea/master.svg)](https://codecov.io/gh/simonepri/is-sea) [![npm](https://img.shields.io/npm/dm/is-sea.svg)](https://www.npmjs.com/package/is-sea) [![npm version](https://img.shields.io/npm/v/is-sea.svg)](https://www.npmjs.com/package/is-sea) [![npm dependencies](https://david-dm.org/simonepri/is-sea.svg)](https://david-dm.org/simonepri/is-sea) [![npm dev dependencies](https://david-dm.org/simonepri/is-sea/dev-status.svg)](https://david-dm.org/simonepri/is-sea#info=devDependencies)
+[![Travis CI](https://travis-ci.org/simonepri/is-sea.svg?branch=master)](https://travis-ci.org/simonepri/is-sea) [![Codecov](https://img.shields.io/codecov/c/github/simonepri/is-sea/master.svg)](https://codecov.io/gh/simonepri/is-sea) [![npm](https://img.shields.io/npm/dm/is-sea.svg)](https://www.npmjs.com/package/is-sea) [![npm version](https://img.shields.io/npm/v/is-sea.svg)](https://www.npmjs.com/package/is-sea) [![npm dependencies](https://david-dm.org/simonepri/is-sea.svg)](https://david-dm.org/simonepri/is-sea) [![npm dev dependencies](https://david-dm.org/simonepri/is-sea/dev-status.svg)](https://david-dm.org/simonepri/is-sea#info=devDependencies) [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20585085.svg)](https://doi.org/10.5281/zenodo.20585085)
 > 🌊 Check whether a geographic coordinate is in the sea or not on the earth.
 
 <p align="center">
@@ -49,6 +49,28 @@ Returns wheather the given point is in the sea or not.
 
 ## Related
 * [country-iso](https://github.com/simonepri/country-iso): 🗺 Get ISO 3166-1 alpha-3 country code from geographic coordinates.
+
+## Citation
+If you use `is-sea` in your research, please cite it using the metadata in [`CITATION.cff`](CITATION.cff), or the following BibTeX entry:
+
+```bibtex
+@software{primarosa_is_sea,
+  author    = {Primarosa, Simone},
+  title     = {{is-sea}: Check whether a geographic coordinate is in the sea or not on the earth},
+  year      = {2017},
+  publisher = {Zenodo},
+  doi       = {10.5281/zenodo.20585085},
+  url       = {https://github.com/simonepri/is-sea}
+}
+```
+
+The concept DOI [`10.5281/zenodo.20585085`](https://doi.org/10.5281/zenodo.20585085) always resolves to the latest release.
+
+## Used in research
+`is-sea` has been used to curate geographic sample metadata in the following peer-reviewed publications:
+
+* Corrêa, F. B., Saraiva, J. P., Stadler, P. F., & Nunes da Rocha, U. (2020). *TerrestrialMetagenomeDB: a public repository of curated and standardized metadata for terrestrial metagenomes.* Nucleic Acids Research, 48(D1), D626–D632. https://doi.org/10.1093/nar/gkz994
+* Nata'ala, M. K., Avila Santos, A. P., Coelho Kasmanas, J., et al. (2022). *MarineMetagenomeDB: a public repository for curated and standardized metadata for marine metagenomes.* Environmental Microbiome, 17, 57. https://doi.org/10.1186/s40793-022-00449-7
 
 ## Authors
 * **Simone Primarosa** - [simonepri](https://github.com/simonepri)


### PR DESCRIPTION
## What

Adds citation metadata and a record of academic usage. **No code changes.**

- **`CITATION.cff`** — enables GitHub's "Cite this repository" button and a machine-readable citation (CFF 1.2.0), pointing at the Zenodo concept DOI.
- **DOI badge** in the header → [10.5281/zenodo.20585085](https://doi.org/10.5281/zenodo.20585085).
- **`## Citation`** section with a ready-to-use BibTeX entry.
- **`## Used in research`** section listing the peer-reviewed databases that use `is-sea` to curate sample coordinates ([TerrestrialMetagenomeDB](https://doi.org/10.1093/nar/gkz994), Nucleic Acids Research; [MarineMetagenomeDB](https://doi.org/10.1186/s40793-022-00449-7), Environmental Microbiome).

## Why

`is-sea` is used by curated metagenome databases to classify whether sample coordinates fall in the sea. A `CITATION.cff` + DOI gives a stable, machine-readable citation so this usage can be attributed (e.g. on Google Scholar).
